### PR TITLE
chore: add web search tool to supervisor

### DIFF
--- a/websocket-server/src/agentConfigs/supervisorAgent.ts
+++ b/websocket-server/src/agentConfigs/supervisorAgent.ts
@@ -215,14 +215,15 @@ export const getNextResponseFromSupervisorFunction: FunctionHandler = {
       const supervisorPrompt = supervisorAgentInstructions;
 
       const tools = [
-        { 
-          type: "function" as const, 
+        { type: "web_search" as const },
+        {
+          type: "function" as const,
           name: lookupKnowledgeBaseFunction.schema.name,
           description: lookupKnowledgeBaseFunction.schema.description || "",
           parameters: lookupKnowledgeBaseFunction.schema.parameters
         },
-        { 
-          type: "function" as const, 
+        {
+          type: "function" as const,
           name: getCurrentTimeFunction.schema.name,
           description: getCurrentTimeFunction.schema.description || "",
           parameters: getCurrentTimeFunction.schema.parameters


### PR DESCRIPTION
## Summary
- allow supervisor agent to perform web searches via Responses API
- limit web search to websocket supervisor configuration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run backend:build`
- `cd websocket-server && npm test` *(fails: Error: no test specified)*
- `cd websocket-server && npx tsc --noEmit`
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68906c0810508328a9d19bac093281ed