### PR TITLE
feat: expose latest server logs

### DIFF
--- a/websocket-server/src/logBuffer.ts
+++ b/websocket-server/src/logBuffer.ts
@@ -1,0 +1,37 @@
+const MAX_LOG_LINES = 200;
+const logBuffer: string[] = [];
+
+type ConsoleMethod = 'log' | 'error' | 'warn' | 'info' | 'debug';
+
+function formatArgs(args: unknown[]): string {
+  return args
+    .map((arg) => {
+      if (typeof arg === 'string') return arg;
+      try {
+        return JSON.stringify(arg);
+      } catch {
+        return String(arg);
+      }
+    })
+    .join(' ');
+}
+
+function addToBuffer(type: ConsoleMethod, args: unknown[]): void {
+  const line = `[${new Date().toISOString()}] ${type.toUpperCase()}: ${formatArgs(args)}`;
+  logBuffer.push(line);
+  if (logBuffer.length > MAX_LOG_LINES) {
+    logBuffer.shift();
+  }
+}
+
+(['log', 'error', 'warn', 'info', 'debug'] as ConsoleMethod[]).forEach((method) => {
+  const original = console[method];
+  console[method] = (...args: any[]) => {
+    addToBuffer(method, args);
+    original.apply(console, args);
+  };
+});
+
+export function getLogs(): string[] {
+  return [...logBuffer];
+}

--- a/websocket-server/src/server.ts
+++ b/websocket-server/src/server.ts
@@ -9,6 +9,7 @@ import cors from "cors";
 import { handleCallConnection, handleFrontendConnection, handleChatConnection, handleTextChatMessage } from "./sessionManager";
 import functions from "./functionHandlers";
 import { openReplyWindow, setNumbers } from './smsState';
+import { getLogs } from "./logBuffer";
 
 dotenv.config();
 
@@ -65,6 +66,11 @@ app.all("/twiml", (req, res) => {
 // New endpoint to list available tools (schemas)
 app.get("/tools", (req, res) => {
   res.json(functions.map((f) => f.schema));
+});
+
+// Endpoint to retrieve latest server logs
+app.get("/logs", (req, res) => {
+  res.type("text/plain").send(getLogs().join("\n"));
 });
 
 // Access token endpoint for voice client


### PR DESCRIPTION
## Summary
- capture last 200 console lines in memory
- add `/logs` endpoint to fetch recent server output

## Testing
- `npm run backend:build`

------
https://chatgpt.com/codex/tasks/task_e_6890866997f88328b1bbacf4c719ac89