### PR TITLE
feat: add CLI hook for agent testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "script:update-app": "node scripts/twilio/update-twiml-app.js",
     "script:validate-token": "node scripts/debug/validate-token.js",
     "script:test-api-key": "node scripts/debug/test-api-key.js",
-    "script:test-direct-api": "node scripts/debug/test-direct-api.js"
+    "script:test-direct-api": "node scripts/debug/test-direct-api.js",
+    "ask": "node scripts/ask.js",
+    "ask:simple": "npm run ask -- \"What is 2 + 2?\"",
+    "ask:complex": "npm run ask -- \"Please escalate this to the supervisor and tell me our company policy on data privacy.\""
   },
   "devDependencies": {
     "concurrently": "^8.2.2"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,6 +16,9 @@ This directory contains utility scripts for managing Twilio Voice integration an
 - **`test-direct-api.js`** - Test direct HTTP API calls to Twilio AU1 region
 - **`validate-token.js`** - Decode and validate Twilio access tokens
 
+### `ask.js` - End-to-end agent test
+- **`ask.js`** - Run a question through the full agent pipeline from the command line
+
 ## 🚀 Quick Usage
 
 ### Generate a Fresh Token
@@ -37,6 +40,12 @@ npm run script:inspect-app
 ```bash
 npm run script:validate-token
 npm run script:test-api-key
+```
+
+### Run an End-to-End Agent Test
+```bash
+npm run ask -- "What is 2 + 2?"      # simple flow
+npm run ask -- "Please escalate this to the supervisor and tell me our company policy on data privacy."  # escalation
 ```
 
 ## 📋 Prerequisites

--- a/scripts/ask.js
+++ b/scripts/ask.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Enable TypeScript support for importing backend modules
+require('../websocket-server/node_modules/ts-node/register');
+const { handleTextChatMessage } = require('../websocket-server/src/sessionManager');
+const WebSocket = require('../websocket-server/node_modules/ws');
+
+class MockWebSocket {
+  constructor() {
+    this.readyState = WebSocket.OPEN;
+    this.messages = [];
+  }
+  send(data) {
+    this.messages.push(data);
+  }
+}
+
+async function main() {
+  const question = process.argv.slice(2).join(' ').trim();
+  if (!question) {
+    console.error('Usage: npm run ask -- "Your question"');
+    process.exit(1);
+  }
+
+  const chatSocket = new MockWebSocket();
+  const logsSocket = new MockWebSocket();
+
+  const chatClients = new Set([chatSocket]);
+  const logsClients = new Set([logsSocket]);
+
+  await handleTextChatMessage(question, chatClients, logsClients);
+
+  // Output chat responses
+  for (const msg of chatSocket.messages) {
+    try {
+      const parsed = JSON.parse(msg);
+      if (parsed.type === 'chat.response') {
+        console.log(parsed.content);
+      } else if (parsed.type === 'chat.error') {
+        console.error('Error:', parsed.error);
+      }
+    } catch (err) {
+      console.log(msg);
+    }
+  }
+}
+
+main().catch(err => {
+  console.error('Unhandled error:', err);
+  process.exit(1);
+});

--- a/websocket-server/package-lock.json
+++ b/websocket-server/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.21.2",
         "httpdispatcher": "^2.2.0",
+        "https-proxy-agent": "^5.0.1",
         "openai": "^4.67.3",
         "ts-node": "^10.9.2",
         "twilio": "^5.8.0",

--- a/websocket-server/package.json
+++ b/websocket-server/package.json
@@ -21,6 +21,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
     "httpdispatcher": "^2.2.0",
+    "https-proxy-agent": "^5.0.1",
     "openai": "^4.67.3",
     "ts-node": "^10.9.2",
     "twilio": "^5.8.0",

--- a/websocket-server/src/agentConfigs/baseAgent.ts
+++ b/websocket-server/src/agentConfigs/baseAgent.ts
@@ -23,7 +23,7 @@ export const getWeatherFunction: FunctionHandler = {
     const response = await fetch(
       `https://api.open-meteo.com/v1/forecast?latitude=${args.latitude}&longitude=${args.longitude}&current=temperature_2m,wind_speed_10m&hourly=temperature_2m,relative_humidity_2m,wind_speed_10m`
     );
-    const data = await response.json();
+    const data: any = await response.json();
     const currentTemp = data.current?.temperature_2m;
     return JSON.stringify({ temp: currentTemp });
   },

--- a/websocket-server/src/agentConfigs/supervisorAgent.ts
+++ b/websocket-server/src/agentConfigs/supervisorAgent.ts
@@ -2,7 +2,8 @@ import { AgentConfig, FunctionHandler } from './types';
 import { supervisorAgentConfig } from './supervisorAgentConfig';
 import { agentPersonality } from "./personality";
 import { ResponsesFunctionCall, ResponsesFunctionCallOutput, ResponsesInputItem, ResponsesTextInput, ResponsesOutputItem } from '../types';
-import OpenAI from 'openai';
+import OpenAI, { ClientOptions } from 'openai';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 // Knowledge base lookup function for supervisor
 export const lookupKnowledgeBaseFunction: FunctionHandler = {
@@ -87,7 +88,12 @@ export async function handleSupervisorToolCalls(
   let iterations = 0;
   const maxIterations = 5;
   let finalText = "";
-  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const options: ClientOptions = { apiKey: process.env.OPENAI_API_KEY };
+  if (process.env.CODEX_CLI === 'true' && process.env.HTTPS_PROXY) {
+    options.httpAgent = new HttpsProxyAgent(process.env.HTTPS_PROXY);
+    console.debug('OpenAI Client', 'Using proxy agent for Codex environment');
+  }
+  const openai = new OpenAI(options);
   
   // Initial request
   let requestBody: any = {

--- a/websocket-server/src/sessionManager.ts
+++ b/websocket-server/src/sessionManager.ts
@@ -1,5 +1,6 @@
 import { RawData, WebSocket } from "ws";
-import OpenAI from "openai";
+import OpenAI, { ClientOptions } from "openai";
+import { HttpsProxyAgent } from "https-proxy-agent";
 import { ResponsesTextInput } from "./types";
 import { getAllFunctions, getDefaultAgent, FunctionHandler } from "./agentConfigs";
 import { isWindowOpen, getNumbers } from './smsState';
@@ -151,9 +152,14 @@ export async function handleTextChatMessage(content: string, chatClients: Set<We
         console.error("❌ No OpenAI API key set in environment");
         return;
       }
-      session.openaiClient = new OpenAI({
+      const options: ClientOptions = {
         apiKey: process.env.OPENAI_API_KEY,
-      });
+      };
+      if (process.env.CODEX_CLI === 'true' && process.env.HTTPS_PROXY) {
+        options.httpAgent = new HttpsProxyAgent(process.env.HTTPS_PROXY);
+        console.debug('OpenAI Client', 'Using proxy agent for Codex environment');
+      }
+      session.openaiClient = new OpenAI(options);
       console.log("✅ OpenAI REST client initialized for text chat");
     }
     


### PR DESCRIPTION
## Summary
- add `scripts/ask.js` to invoke `handleTextChatMessage` from the CLI
- expose `npm run ask`, `ask:simple`, and `ask:complex` helper commands
- document usage and sample questions for normal and escalation flows
- fix strict type in `getWeatherFunction`
- support proxies for OpenAI clients when `CODEX_CLI` and `HTTPS_PROXY` are set

## Testing
- `npm run backend:build`
- `npm run ask:simple` (fails: ENETUNREACH)
- `npm run ask:complex` (fails: ENETUNREACH)


------
https://chatgpt.com/codex/tasks/task_e_6890858115ec83288d5a8a38845f3ec6