### PR TITLE
feat: send notification after servers start

### DIFF
--- a/scripts/notify-on-start.js
+++ b/scripts/notify-on-start.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Wait for specified servers to become available and send a notification
+// using a custom endpoint defined via environment variables.
+
+const endpoint = process.env.CALL_MY_PHONE_ENDPOINT;
+const secret = process.env.CALL_MY_PHONE_SECRET;
+const backendUrl = process.env.BACKEND_URL;
+const frontendUrl = process.env.FRONTEND_URL;
+const message = process.env.STARTUP_NOTIFY_MESSAGE || 'Servers started successfully';
+
+async function waitFor(url) {
+  // Poll the given URL until it responds without error.
+  // Uses HEAD requests to minimize data transfer.
+  while (true) {
+    try {
+      const res = await fetch(url, { method: 'HEAD' });
+      if (res.ok) return;
+    } catch (err) {
+      // Ignore errors and retry
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+}
+
+async function notify(msg) {
+  if (!endpoint || !secret) {
+    console.log('Notification skipped: CALL_MY_PHONE_ENDPOINT or CALL_MY_PHONE_SECRET not set');
+    return;
+  }
+  try {
+    const resp = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ secret, message: msg }),
+    });
+    if (!resp.ok) {
+      console.error('Failed to send notification:', resp.status, await resp.text());
+    } else {
+      console.log('Startup notification sent');
+    }
+  } catch (err) {
+    console.error('Failed to send notification:', err.message);
+  }
+}
+
+(async () => {
+  try {
+    const waits = [];
+    if (backendUrl) waits.push(waitFor(backendUrl));
+    if (frontendUrl) waits.push(waitFor(frontendUrl));
+    await Promise.all(waits);
+    await notify(message);
+  } catch (err) {
+    console.error('Error waiting for servers:', err.message);
+  }
+})();
+

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "node ../scripts/notify-on-start.js & next start",
     "lint": "next lint"
   },
   "dependencies": {

--- a/websocket-server/package.json
+++ b/websocket-server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc && npm run copy-assets",
     "copy-assets": "cp src/twiml.xml dist/",
-    "start": "node dist/server.js",
+    "start": "node ../scripts/notify-on-start.js & node dist/server.js",
     "dev": "nodemon --watch 'src/**/*' --watch '.env' --ext 'ts,js,xml,env' --exec 'ts-node' src/server.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
## Summary
- wire up notify-on-start script in each application's npm start
- allow notification script to wait only on the URLs provided via env vars
- start scripts rely on deployment environment variables without hard-coded URLs

## Testing
- `npm test` *(fails: Missing script)*
- `(cd websocket-server && npm test)` *(fails: Error: no test specified)*
- `(cd webapp && npm test)` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68908998571083289a93eae984829fd7