### PR TITLE
feat: add logs button to session settings

### DIFF
--- a/webapp/components/session-configuration-panel.tsx
+++ b/webapp/components/session-configuration-panel.tsx
@@ -149,6 +149,10 @@ const SessionConfigurationPanel: React.FC<SessionConfigurationPanelProps> = ({
     return backendTools.some((t: any) => t.name === name);
   };
 
+  const handleOpenLogs = () => {
+    window.open(`${getBackendUrl()}/logs`, "_blank");
+  };
+
   return (
     <Card className="flex flex-col h-full w-full mx-auto">
       <CardHeader className="pb-0 px-4 sm:px-6">
@@ -157,6 +161,9 @@ const SessionConfigurationPanel: React.FC<SessionConfigurationPanelProps> = ({
             Session Configuration
           </CardTitle>
           <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm" onClick={handleOpenLogs}>
+              Open Logs
+            </Button>
             {saveStatus === "error" ? (
               <span className="text-xs text-red-500 flex items-center gap-1">
                 <AlertCircle className="h-3 w-3" />


### PR DESCRIPTION
## Summary
- add "Open Logs" button to session configuration

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68912b98236c8328b6d66c6f24bc6f2e