### PR TITLE
feat: expose canvas message for escalations

### DIFF
--- a/webapp/lib/handle-enhanced-realtime-event.ts
+++ b/webapp/lib/handle-enhanced-realtime-event.ts
@@ -190,16 +190,27 @@ export default function handleEnhancedRealtimeEvent(
       );
 
       // Add breadcrumb for chat response
-      const chatBreadcrumbTitle = chatSupervisor 
+      const chatBreadcrumbTitle = chatSupervisor
         ? "🧠 Supervisor chat response"
         : "💬 Chat response";
-        
+
       addTranscriptBreadcrumb(
         chatBreadcrumbTitle,
         {
           content: event.content,
           timestamp: event.timestamp,
           supervisor: chatSupervisor
+        }
+      );
+      break;
+
+    case "chat.canvas":
+      addTranscriptBreadcrumb(
+        "📝 Canvas response",
+        {
+          content: event.content,
+          timestamp: event.timestamp,
+          supervisor: event.supervisor || false
         }
       );
       break;


### PR DESCRIPTION
## Summary
- request the base agent to return JSON with a short `summary` and full `canvas`
- parse and forward canvas content using new `chat.canvas` event
- handle `chat.canvas` events on the web client as breadcrumbs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run backend:build`
- `npm run frontend:build`


------
https://chatgpt.com/codex/tasks/task_e_68912d3dfaec8328ba1a7f23307aa86d