### PR TITLE
feat(webapp): show build commit info in settings panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Single-threaded, multi-channel AI assistant with voice, text, and phone capabilities",
   "private": true,
   "scripts": {
+    "generate-build-info": "node scripts/write-build-info.js",
+    "predev": "npm run generate-build-info",
+    "prebuild": "npm run generate-build-info",
+    "prestart": "npm run generate-build-info",
     "dev": "concurrently \"npm run backend:dev\" \"npm run frontend:dev\"",
     "dev:core": "concurrently \"npm run backend:dev\" \"npm run frontend:dev\"",
     "start": "concurrently \"npm run backend:start\" \"npm run frontend:start\"",

--- a/scripts/write-build-info.js
+++ b/scripts/write-build-info.js
@@ -1,0 +1,23 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function getGitInfo() {
+  const commitId = execSync('git rev-parse --short HEAD').toString().trim();
+  const commitMessage = execSync('git log -1 --pretty=%s').toString().trim();
+  return { commitId, commitMessage };
+}
+
+function writeBuildInfo() {
+  try {
+    const info = getGitInfo();
+    const outputPath = path.resolve(__dirname, '../webapp/public/build-info.json');
+    fs.writeFileSync(outputPath, JSON.stringify(info, null, 2));
+    console.log('Build info written to', outputPath);
+  } catch (err) {
+    console.error('Failed to write build info', err);
+    process.exit(1);
+  }
+}
+
+writeBuildInfo();

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -19,6 +19,7 @@
 # misc
 .DS_Store
 *.pem
+public/build-info.json
 
 # debug
 npm-debug.log*

--- a/webapp/components/session-configuration-panel.tsx
+++ b/webapp/components/session-configuration-panel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Select,
@@ -40,9 +40,22 @@ const SessionConfigurationPanel: React.FC<SessionConfigurationPanelProps> = ({
     "idle" | "saving" | "saved" | "error"
   >("idle");
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  const [buildInfo, setBuildInfo] = useState<{ commitId: string; commitMessage: string } | null>(
+    null
+  );
 
   // Fetch backend tools once (no polling since tools are static)
   const backendTools = useBackendTools(`${getBackendUrl()}/tools`, 0);
+
+  // Load build metadata
+  useEffect(() => {
+    fetch("/build-info.json")
+      .then((res) => res.json())
+      .then(setBuildInfo)
+      .catch(() => {
+        /* ignore */
+      });
+  }, []);
 
   // Track changes to determine if there are unsaved modifications
   useEffect(() => {
@@ -272,6 +285,14 @@ const SessionConfigurationPanel: React.FC<SessionConfigurationPanelProps> = ({
           </div>
         </ScrollArea>
       </CardContent>
+      <CardFooter className="flex-col items-center text-xs text-muted-foreground">
+        {buildInfo && (
+          <>
+            <div>Commit {buildInfo.commitId}</div>
+            <div>{buildInfo.commitMessage}</div>
+          </>
+        )}
+      </CardFooter>
 
       <ToolConfigurationDialog
         open={openDialog}

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "generate-build-info": "node ../scripts/write-build-info.js",
+    "predev": "npm run generate-build-info",
+    "prebuild": "npm run generate-build-info",
+    "prestart": "npm run generate-build-info",
     "dev": "node ../scripts/notify-on-start.js & next dev",
     "build": "next build",
     "start": "node ../scripts/notify-on-start.js & next start",


### PR DESCRIPTION
## Summary
- run build-info generation before dev, build, and start
- surface current commit id and message in the existing settings dialog

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build`
- `npm run dev` *(terminated after verifying build info generation)*

------
https://chatgpt.com/codex/tasks/task_e_68912c0ae7d08328b86a15df234f852f