### PR TITLE
Remove knowledge base lookup tool

### DIFF
--- a/websocket-server/src/agentConfigs/supervisorAgent.ts
+++ b/websocket-server/src/agentConfigs/supervisorAgent.ts
@@ -4,11 +4,11 @@ import { ResponsesFunctionCall, ResponsesFunctionCallOutput, ResponsesInputItem,
 import OpenAI, { ClientOptions } from 'openai';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 
-import { lookupKnowledgeBaseFunction, getCurrentTimeFunction } from './supervisorTools';
+import { getCurrentTimeFunction } from './supervisorTools';
 
 // Supervisor tool response handler
 export async function getSupervisorToolResponse(functionName: string, args: any): Promise<string> {
-  const supervisorTools = [lookupKnowledgeBaseFunction, getCurrentTimeFunction];
+  const supervisorTools = [getCurrentTimeFunction];
   const tool = supervisorTools.find(t => t.schema.name === functionName);
   
   if (!tool) {
@@ -169,12 +169,6 @@ export const getNextResponseFromSupervisorFunction: FunctionHandler = {
 
       const tools = [
         { type: "web_search" as const },
-        {
-          type: "function" as const,
-          name: lookupKnowledgeBaseFunction.schema.name,
-          description: lookupKnowledgeBaseFunction.schema.description || "",
-          parameters: lookupKnowledgeBaseFunction.schema.parameters
-        },
         {
           type: "function" as const,
           name: getCurrentTimeFunction.schema.name,

--- a/websocket-server/src/agentConfigs/supervisorAgentConfig.ts
+++ b/websocket-server/src/agentConfigs/supervisorAgentConfig.ts
@@ -1,8 +1,5 @@
 import { AgentConfig } from './types';
-import {
-  getCurrentTimeFunction,
-  lookupKnowledgeBaseFunction
-} from './supervisorTools';
+import { getCurrentTimeFunction } from './supervisorTools';
 import { agentPersonality } from "./personality";
 
 // Supervisor Agent Configuration
@@ -25,7 +22,6 @@ Guidelines:
 - Format your response for direct relay to the user.`,
   voice: agentPersonality.voice,
   tools: [
-    lookupKnowledgeBaseFunction,
     getCurrentTimeFunction
   ],
   model: "gpt-4o",

--- a/websocket-server/src/agentConfigs/supervisorTools.ts
+++ b/websocket-server/src/agentConfigs/supervisorTools.ts
@@ -1,37 +1,5 @@
 import { FunctionHandler } from './types';
 
-// Knowledge base lookup function for supervisor
-export const lookupKnowledgeBaseFunction: FunctionHandler = {
-  schema: {
-    name: "lookupKnowledgeBase",
-    type: "function",
-    description: "Look up information from the knowledge base by topic or keyword.",
-    parameters: {
-      type: "object",
-      properties: {
-        topic: {
-          type: "string",
-          description: "The topic or keyword to search for in the knowledge base."
-        }
-      },
-      required: ["topic"],
-      additionalProperties: false
-    }
-  },
-  handler: async (args: { topic: string }) => {
-    // Simulate knowledge base lookup
-    const knowledgeBase = {
-      "company_policy": "Our company follows strict data privacy guidelines and customer service standards.",
-      "product_info": "We offer various AI assistant services with different capability tiers.",
-      "technical_support": "For technical issues, we provide 24/7 support with escalation procedures."
-    };
-
-    const result = knowledgeBase[args.topic as keyof typeof knowledgeBase] ||
-                  "No specific information found for this topic.";
-    return JSON.stringify({ result, topic: args.topic });
-  },
-};
-
 // Get current time function for supervisor
 export const getCurrentTimeFunction: FunctionHandler = {
   schema: {
@@ -53,4 +21,3 @@ export const getCurrentTimeFunction: FunctionHandler = {
     });
   },
 };
-


### PR DESCRIPTION
## Summary
- remove knowledge base lookup tool from supervisor tools
- update supervisor agent to only expose current time and web search

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd websocket-server && npm test` *(fails: Error: no test specified)*
- `cd websocket-server && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891367730008328b6e5983cfcec772f