### PR TITLE
feat: add canvas broadcast tool to base agent

### DIFF
--- a/websocket-server/src/agentConfigs/baseAgent.ts
+++ b/websocket-server/src/agentConfigs/baseAgent.ts
@@ -1,4 +1,5 @@
 import { AgentConfig, FunctionHandler } from './types';
+import { sendCanvas } from './canvasTool';
 
 // Weather function - basic utility function
 export const getWeatherFunction: FunctionHandler = {
@@ -31,3 +32,4 @@ export const getWeatherFunction: FunctionHandler = {
 
 // Import the base agent configuration
 export { baseAgentConfig as baseAgent } from './baseAgentConfig';
+export { sendCanvas };

--- a/websocket-server/src/agentConfigs/baseAgentConfig.ts
+++ b/websocket-server/src/agentConfigs/baseAgentConfig.ts
@@ -1,5 +1,5 @@
 import { AgentConfig } from './types';
-import { getWeatherFunction } from './baseAgent';
+import { getWeatherFunction, sendCanvas } from './baseAgent';
 import { agentPersonality } from "./personality";
 
 // Base Agent Configuration
@@ -22,7 +22,7 @@ Use the getNextResponseFromSupervisor function to escalate to a more powerful re
 
 Be conversational and natural in speech. When escalating, choose the appropriate reasoning_type and provide good context.`,
   voice: agentPersonality.voice,
-  tools: [getWeatherFunction],
+  tools: [getWeatherFunction, sendCanvas],
   model: "gpt-4o-realtime-preview-2024-10-01",
   temperature: 0.8,
 };

--- a/websocket-server/src/agentConfigs/canvasTool.ts
+++ b/websocket-server/src/agentConfigs/canvasTool.ts
@@ -1,0 +1,40 @@
+import { FunctionHandler } from './types';
+import { WebSocket } from 'ws';
+
+function jsonSend(ws: WebSocket | undefined, obj: unknown) {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify(obj));
+}
+
+export const sendCanvas: FunctionHandler = {
+  schema: {
+    name: "send_canvas",
+    type: "function",
+    description: "Send detailed content to the canvas UI.",
+    parameters: {
+      type: "object",
+      properties: {
+        content: { type: "string" },
+        title: { type: "string" }
+      },
+      required: ["content"],
+      additionalProperties: false
+    }
+  },
+  handler: async ({ content, title }: { content: string; title?: string }) => {
+    const message = { type: "chat.canvas", content, title, timestamp: Date.now() };
+
+    const globals = globalThis as any;
+    const chatClients: Set<WebSocket> = globals.chatClients ?? new Set();
+    const logsClients: Set<WebSocket> = globals.logsClients ?? new Set();
+
+    for (const client of chatClients) {
+      jsonSend(client, message);
+    }
+    for (const client of logsClients) {
+      jsonSend(client, message);
+    }
+
+    return "canvas_sent";
+  }
+};


### PR DESCRIPTION
## Summary
- add sendCanvas tool for broadcasting canvas updates to chat/log clients
- wire sendCanvas into base agent configuration so models can call the tool

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`
- `node -e "const { getAllFunctions } = require('./websocket-server/dist/agentConfigs'); console.log(getAllFunctions().map(f=>f.schema.name))"`


------
https://chatgpt.com/codex/tasks/task_e_689160a9700c8328a447fd3bd96ad818