### PR TITLE
Simplify supervisor escalation responses

### DIFF
--- a/websocket-server/src/agentConfigs/baseAgentConfig.ts
+++ b/websocket-server/src/agentConfigs/baseAgentConfig.ts
@@ -11,6 +11,8 @@ You are a fast voice AI assistant called with access to a supervisor agent for c
 
 For simple conversations, greetings, basic questions, and quick responses, handle them directly with natural speech.
 
+Keep responses concise—no more than two or three sentences.
+
 For complex queries that require:
 - Multi-step analysis or planning
 - Technical deep-dives  

--- a/websocket-server/src/sessionManager.ts
+++ b/websocket-server/src/sessionManager.ts
@@ -294,7 +294,7 @@ export async function handleTextChatMessage(content: string, chatClients: Set<We
             model: "gpt-4o",
             previous_response_id: response.id,
             instructions:
-              "Using the supervisor's result, reply in JSON with keys 'summary' (max two sentences) and 'canvas' (detailed response).",
+              "Using the supervisor's result, provide a concise plain-text answer in two or three sentences.",
             input: [
               {
                 type: "function_call_output" as const,
@@ -305,7 +305,7 @@ export async function handleTextChatMessage(content: string, chatClients: Set<We
                     : JSON.stringify(functionResult)
               }
             ],
-            max_output_tokens: 1000
+            max_output_tokens: 500
           };
 
           console.log("[DEBUG] Follow-up Responses API request:", JSON.stringify(followUpBody, null, 2));
@@ -326,23 +326,8 @@ export async function handleTextChatMessage(content: string, chatClients: Set<We
           // Update conversation state with new response id
           session.previousResponseId = followUpResponse.id;
 
-          // Parse summary and canvas from the response
-          let finalResponse = "Supervisor agent completed.";
-          let canvasMessage = "";
-          try {
-            if (followUpResponse.output_text) {
-              const parsed = JSON.parse(followUpResponse.output_text);
-              finalResponse = parsed.summary || finalResponse;
-              canvasMessage = parsed.canvas || "";
-            }
-          } catch (e) {
-            console.warn("Failed to parse supervisor JSON:", e);
-            finalResponse = followUpResponse.output_text || finalResponse;
-            canvasMessage =
-              typeof functionResult === "string"
-                ? functionResult
-                : JSON.stringify(functionResult);
-          }
+          const finalResponse =
+            followUpResponse.output_text || "Supervisor agent completed.";
 
           // Add assistant response to conversation history
           const assistantMessage = {
@@ -353,7 +338,7 @@ export async function handleTextChatMessage(content: string, chatClients: Set<We
           };
           session.conversationHistory.push(assistantMessage);
 
-          // Send short summary back to chat clients
+          // Send response back to chat clients
           for (const ws of chatClients) {
             if (isOpen(ws))
               jsonSend(ws, {
@@ -362,18 +347,9 @@ export async function handleTextChatMessage(content: string, chatClients: Set<We
                 timestamp: Date.now(),
                 supervisor: true
               });
-            if (canvasMessage) {
-              if (isOpen(ws))
-                jsonSend(ws, {
-                  type: "chat.canvas",
-                  content: canvasMessage,
-                  timestamp: Date.now(),
-                  supervisor: true
-                });
-            }
           }
 
-          // Forward assistant summary to observability clients
+          // Forward assistant response to observability clients
           for (const ws of logsClients) {
             if (isOpen(ws))
               jsonSend(ws, {
@@ -386,13 +362,6 @@ export async function handleTextChatMessage(content: string, chatClients: Set<We
                   channel: "text",
                   supervisor: true
                 }
-              });
-            if (canvasMessage && isOpen(ws))
-              jsonSend(ws, {
-                type: "chat.canvas",
-                content: canvasMessage,
-                timestamp: Date.now(),
-                supervisor: true
               });
           }
         } else {


### PR DESCRIPTION
## Summary
- Instruct base agent to keep replies brief and under three sentences
- Remove JSON/canvas parsing from supervisor follow-up and return plain text

## Testing
- `cd websocket-server && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68913e6b47e88328a467a4bb4ba7fd6b