### PR TITLE
Include sendCanvas in follow-up requests

### DIFF
--- a/websocket-server/src/agentConfigs/baseAgentConfig.ts
+++ b/websocket-server/src/agentConfigs/baseAgentConfig.ts
@@ -11,11 +11,11 @@ You are a fast voice AI assistant called with access to a supervisor agent for c
 
 For simple conversations, greetings, basic questions, and quick responses, handle them directly with natural speech.
 
-Keep responses concise—no more than two or three sentences.
+Keep responses concise—no more than two or three sentences. If that would omit important details, use the sendCanvas tool to share the full response.
 
 For complex queries that require:
 - Multi-step analysis or planning
-- Technical deep-dives  
+- Technical deep-dives
 - Creative problem-solving
 - Detailed research or reasoning
 - Complex calculations or logic

--- a/websocket-server/src/sessionManager.ts
+++ b/websocket-server/src/sessionManager.ts
@@ -290,11 +290,12 @@ export async function handleTextChatMessage(content: string, chatClients: Set<We
           }
 
           // Follow-up request to complete tool call and have base agent respond
+          const functionSchemas = allFunctions.map((f: FunctionHandler) => f.schema);
           const followUpBody = {
             model: "gpt-4o",
             previous_response_id: response.id,
             instructions:
-              "Using the supervisor's result, provide a concise plain-text answer in two or three sentences.",
+              "Using the supervisor's result, provide a concise plain-text answer in two or three sentences. If important details would be lost, use the sendCanvas tool to deliver the full response.",
             input: [
               {
                 type: "function_call_output" as const,
@@ -305,6 +306,7 @@ export async function handleTextChatMessage(content: string, chatClients: Set<We
                     : JSON.stringify(functionResult)
               }
             ],
+            tools: functionSchemas,
             max_output_tokens: 500
           };
 


### PR DESCRIPTION
## Summary
- allow longer answers by adding sendCanvas guidance to base agent instructions
- ensure follow-up requests include sendCanvas tool and mention it in instructions

## Testing
- `npm test` (fails: Missing script: "test")
- `cd websocket-server && npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68916617cb048328bd480ae669270bf7