### PR TITLE
Add SMS reply handling for follow-up responses

### DIFF
--- a/websocket-server/src/sessionManager.ts
+++ b/websocket-server/src/sessionManager.ts
@@ -366,6 +366,15 @@ export async function handleTextChatMessage(content: string, chatClients: Set<We
                 }
               });
           }
+          // --- SMS reply window logic ---
+          try {
+            if (isWindowOpen()) {
+              const { smsUserNumber, smsTwilioNumber } = getNumbers();
+              await sendSms(finalResponse, smsTwilioNumber, smsUserNumber);
+            }
+          } catch (e) {
+            console.error('sendSms error', e);
+          }
         } else {
           console.error(`❌ Function handler not found: ${functionCall.name}`);
         }


### PR DESCRIPTION
## Summary
- Send SMS replies for follow-up responses when the SMS window is open

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68918b507f188328a00a2878392f7671