### PR TITLE
feat: inline voice mini app

### DIFF
--- a/webapp/components/call-interface.tsx
+++ b/webapp/components/call-interface.tsx
@@ -3,8 +3,7 @@
 import React, { useState, useEffect } from "react";
 import TopBar from "@/components/top-bar";
 import { Dialog, DialogTrigger, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import { Settings, Mic } from "lucide-react";
-import VoiceMiniApp from "@/components/voice-mini-app";
+import { Settings } from "lucide-react";
 import SessionConfigurationPanel from "@/components/session-configuration-panel";
 import { EnhancedTranscript } from "@/components/enhanced-transcript";
 
@@ -34,7 +33,6 @@ const CallInterface = () => {
   const [chatWs, setChatWs] = useState<WebSocket | null>(null);
   const [chatStatus, setChatStatus] = useState<'connected' | 'disconnected' | 'connecting'>('disconnected');
   const [userText, setUserText] = useState("");
-  const [voiceAppOpen, setVoiceAppOpen] = useState(false);
   const transcript = useTranscript();
   
   const canSendChat = chatStatus === 'connected' && userText.trim().length > 0;
@@ -128,15 +126,6 @@ const CallInterface = () => {
 
   return (
     <div className="h-screen bg-white flex flex-col">
-      <Dialog open={voiceAppOpen} onOpenChange={setVoiceAppOpen}>
-        <DialogContent className="max-w-sm w-full">
-          {/* Accessibility: DialogTitle for screen readers */}
-          <span style={{position: 'absolute', width: 1, height: 1, padding: 0, margin: -1, overflow: 'hidden', clip: 'rect(0,0,0,0)', border: 0}}>
-            <DialogTitle>Voice Mini App</DialogTitle>
-          </span>
-          <VoiceMiniApp />
-        </DialogContent>
-      </Dialog>
       <Dialog open={setupDialogOpen} onOpenChange={setSetupDialogOpen}>
         <TopBar>
           <ServiceChecklist
@@ -144,13 +133,6 @@ const CallInterface = () => {
             allConfigsReady={allConfigsReady}
             setAllConfigsReady={setAllConfigsReady}
           />
-          <button
-            className="p-2 rounded-full hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary"
-            aria-label="Open voice mini app"
-            onClick={() => setVoiceAppOpen(true)}
-          >
-            <Mic className="w-5 h-5" />
-          </button>
           <DialogTrigger asChild>
             <button
               className="p-2 rounded-full hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary"

--- a/webapp/components/enhanced-transcript.tsx
+++ b/webapp/components/enhanced-transcript.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useTranscript } from "@/contexts/TranscriptContext";
 import { ChevronRightIcon, ClipboardIcon } from "@heroicons/react/24/outline";
+import VoiceMiniApp from "@/components/voice-mini-app";
 
 export interface EnhancedTranscriptProps {
   userText: string;
@@ -196,8 +197,8 @@ export function EnhancedTranscript({
           })}
       </div>
 
-      {/* Input Area - Fixed at bottom */}
-      <div className="flex-shrink-0 border-t border-gray-200 p-4">
+      {/* Input Area and Voice Mini App */}
+      <div className="flex-shrink-0 border-t border-gray-200 p-4 space-y-4">
         <div className="flex items-center gap-2">
           <input
             ref={inputRef}
@@ -220,6 +221,7 @@ export function EnhancedTranscript({
             Send
           </button>
         </div>
+        <VoiceMiniApp />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- remove voice app overlay and its mic trigger in the call interface
- embed voice mini app below the chat input for inline access

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891c9d8cee0832882fea535a4e24a12