### PR TITLE
feat: add localtunnel helper scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ generate-token.js
 .DS_Store
 websocket-server/session-data.json
 websocket-server/dist
+scripts/localtunnel/*.log

--- a/scripts/localtunnel.js
+++ b/scripts/localtunnel.js
@@ -2,10 +2,8 @@
 
 // scripts/localtunnel.js
 // Starts localtunnel for backend server if CODEX_CLI is 'true'.
-import { HttpProxyAgent } from 'http-proxy-agent';
-
+const { HttpProxyAgent } = require('http-proxy-agent');
 const localtunnel = require('localtunnel');
-const fetch = require('node-fetch');
 const fs = require('fs');
 
 const PORT = process.env.PORT || 8081;
@@ -16,7 +14,7 @@ const agent = new HttpProxyAgent(process.env.HTTP_PROXY);
 
 async function getTunnelPassword() {
   try {
-    const res = await fetch('ipv4.icanhazip.com', { agent });
+    const res = await fetch('http://ipv4.icanhazip.com', { agent });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const text = await res.text();
     return text.trim();

--- a/scripts/localtunnel/README.md
+++ b/scripts/localtunnel/README.md
@@ -1,0 +1,35 @@
+# Localtunnel Helper Options
+
+This directory contains helper scripts for starting the development tunnel.
+Choose the one that best fits your environment.
+
+## 1. `start-localtunnel.sh`
+Bash wrapper that runs `../localtunnel.js` in the background.
+It waits for the public URL to appear, prints the startup log, and then
+detaches the process.
+
+```bash
+CODEX_CLI=true scripts/localtunnel/start-localtunnel.sh
+```
+
+Logs are written to `scripts/localtunnel/localtunnel.log`.
+
+## 2. `spawn-localtunnel.js`
+Node script that spawns `../localtunnel.js`, streams its initial output,
+then detaches so other tasks can continue.
+
+```bash
+CODEX_CLI=true node scripts/localtunnel/spawn-localtunnel.js
+```
+
+## 3. `inline-localtunnel.js`
+Starts the tunnel directly using the `localtunnel` package. Useful when you
+want to embed tunneling inside your setup process and continue with other
+JavaScript tasks.
+
+```bash
+node scripts/localtunnel/inline-localtunnel.js
+```
+
+All scripts respect `CODEX_PROXY_CERT` and `HTTP_PROXY` if set. The first two
+options require `CODEX_CLI=true` because they wrap `scripts/localtunnel.js`.

--- a/scripts/localtunnel/inline-localtunnel.js
+++ b/scripts/localtunnel/inline-localtunnel.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Start localtunnel directly inside this script.
+const { HttpProxyAgent } = require('http-proxy-agent');
+const localtunnel = require('localtunnel');
+const fs = require('fs');
+
+const PORT = process.env.PORT || 8081;
+const CODEX_PROXY_CERT = process.env.CODEX_PROXY_CERT;
+const agent = new HttpProxyAgent(process.env.HTTP_PROXY);
+
+async function getTunnelPassword() {
+  try {
+    const res = await fetch('http://ipv4.icanhazip.com', { agent });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const text = await res.text();
+    return text.trim();
+  } catch (err) {
+    console.error('[inline-localtunnel] Failed to fetch tunnel password:', err);
+    return null;
+  }
+}
+
+(async () => {
+  try {
+    const ltOptions = { port: PORT, subdomain: undefined };
+    if (CODEX_PROXY_CERT && fs.existsSync(CODEX_PROXY_CERT)) {
+      ltOptions.local_ca = CODEX_PROXY_CERT;
+      console.log(`[inline-localtunnel] Using local_ca: ${CODEX_PROXY_CERT}`);
+    } else if (CODEX_PROXY_CERT) {
+      console.warn(`[inline-localtunnel] CODEX_PROXY_CERT set but file does not exist: ${CODEX_PROXY_CERT}`);
+    }
+    const password = await getTunnelPassword();
+    if (password) {
+      console.log(`\n[inline-localtunnel] Tunnel password: ${password}`);
+    }
+    const tunnel = await localtunnel(ltOptions);
+    console.log(`\n[inline-localtunnel] Public URL: ${tunnel.url}`);
+    // Continue with other setup tasks while tunnel stays open
+  } catch (err) {
+    console.error('[inline-localtunnel] Failed to start:', err);
+    process.exit(1);
+  }
+})();

--- a/scripts/localtunnel/spawn-localtunnel.js
+++ b/scripts/localtunnel/spawn-localtunnel.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Spawn localtunnel.js and detach after showing startup output.
+const { spawn } = require('child_process');
+const path = require('path');
+
+if (process.env.CODEX_CLI !== 'true') {
+  console.log('[spawn-localtunnel] Skipped: CODEX_CLI is not "true"');
+  process.exit(0);
+}
+
+const scriptPath = path.join(__dirname, '..', 'localtunnel.js');
+const lt = spawn('node', [scriptPath], {
+  detached: true,
+  stdio: ['ignore', 'pipe', 'inherit'],
+});
+
+let buffer = '';
+lt.stdout.on('data', chunk => {
+  const text = chunk.toString();
+  buffer += text;
+  process.stdout.write(text);
+  if (buffer.includes('Public URL')) {
+    lt.stdout.destroy();
+    lt.unref();
+    lt.stdout.unref();
+  }
+});

--- a/scripts/localtunnel/start-localtunnel.sh
+++ b/scripts/localtunnel/start-localtunnel.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Run localtunnel.js in background, show startup info, then detach.
+set -euo pipefail
+
+if [ "${CODEX_CLI:-}" != "true" ]; then
+  echo "[start-localtunnel] Skipped: CODEX_CLI is not 'true'"
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG_FILE="$SCRIPT_DIR/localtunnel.log"
+
+node "$SCRIPT_DIR/../localtunnel.js" > "$LOG_FILE" 2>&1 &
+LT_PID=$!
+
+until grep -q "Public URL" "$LOG_FILE"; do sleep 1; done
+head -n 20 "$LOG_FILE"
+
+disown "$LT_PID"


### PR DESCRIPTION
## Summary
- add helper scripts for starting localtunnel in different ways
- document usage for the new scripts
- switch localtunnel.js to CommonJS and ignore generated logs

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891cb27f7a483289235577ca2e521ac