### PR TITLE
Greet Twilio callers on connect

### DIFF
--- a/websocket-server/src/sessionManager.ts
+++ b/websocket-server/src/sessionManager.ts
@@ -474,7 +474,7 @@ function tryConnectModel() {
 
   session.modelConn.on("open", () => {
     const config = session.saved_config || {};
-    
+
     // Include supervisor agent function for voice channel
     const allFunctions = getAllFunctions();
     const functionSchemas = allFunctions.map((f: FunctionHandler) => f.schema);
@@ -493,6 +493,16 @@ function tryConnectModel() {
         ...config,
       },
     });
+
+    // Send a friendly greeting when a Twilio caller connects
+    if (session.twilioConn) {
+      jsonSend(session.modelConn, {
+        type: "response.create",
+        response: {
+          instructions: "Greet the caller briefly in a style that aligns with your given personality before awaiting input.",
+        },
+      });
+    }
   });
 
   session.modelConn.on("message", (data: RawData) => handleModelMessage(data, global.logsClients ?? new Set(), global.chatClients ?? new Set()));


### PR DESCRIPTION
## Summary
- Configure realtime session with base agent instructions and greet Twilio callers briefly on connection.
- Remove redundant personality instructions from greeting since session already holds them.
- Ensure greeting references the agent's personality context.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd websocket-server && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68934b5d5f308328a22c958be276e4f6