### PR TITLE
Send SMS placeholder for tool calls

### DIFF
--- a/websocket-server/src/sessionManager.ts
+++ b/websocket-server/src/sessionManager.ts
@@ -289,7 +289,13 @@ export async function handleTextChatMessage(content: string, chatClients: Set<We
           call_id: functionCall.call_id
         });
       }
-      
+
+      // --- SMS placeholder for tool call ---
+      if (isWindowOpen()) {
+        const { smsUserNumber, smsTwilioNumber } = getNumbers();
+        sendSms('...', smsTwilioNumber, smsUserNumber).catch(e => console.error('sendSms error', e));
+      }
+
       try {
         // Find and execute the function
         const allFunctions = getAllFunctions();
@@ -307,6 +313,11 @@ export async function handleTextChatMessage(content: string, chatClients: Set<We
                 arguments: JSON.stringify(data || {}),
                 call_id: `supervisor_${Date.now()}`
               });
+            }
+            // --- SMS placeholder for nested tool call ---
+            if (isWindowOpen()) {
+              const { smsUserNumber, smsTwilioNumber } = getNumbers();
+              sendSms('...', smsTwilioNumber, smsUserNumber).catch(e => console.error('sendSms error', e));
             }
           };
           


### PR DESCRIPTION
## Summary
- send "..." via SMS when tool call breadcrumbs are logged
- include nested supervisor tool calls in SMS placeholder notifications
- avoid blocking while sending placeholder SMS

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run backend:build`


------
https://chatgpt.com/codex/tasks/task_e_6893ce8bf9ac83288fd994facc2b30fc