### PR TITLE
feat: add remote MCP tools support

### DIFF
--- a/data/mcp-tools.json
+++ b/data/mcp-tools.json
@@ -1,0 +1,6 @@
+[
+  {
+    "server_label": "demo_mcp",
+    "server_url": "https://example.com/mcp"
+  }
+]

--- a/websocket-server/src/agentConfigs/supervisorAgent.ts
+++ b/websocket-server/src/agentConfigs/supervisorAgent.ts
@@ -5,6 +5,7 @@ import OpenAI, { ClientOptions } from 'openai';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 
 import { getCurrentTimeFunction } from './supervisorTools';
+import { loadRemoteMcpTools } from '../remoteMcpTools';
 
 // Supervisor tool response handler
 export async function getSupervisorToolResponse(functionName: string, args: any): Promise<string> {
@@ -174,7 +175,8 @@ export const getNextResponseFromSupervisorFunction: FunctionHandler = {
           name: getCurrentTimeFunction.schema.name,
           description: getCurrentTimeFunction.schema.description || "",
           parameters: getCurrentTimeFunction.schema.parameters
-        }
+        },
+        ...loadRemoteMcpTools()
       ];
 
       // Initial user input as message input

--- a/websocket-server/src/remoteMcpTools.ts
+++ b/websocket-server/src/remoteMcpTools.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+interface RemoteMcpConfig {
+  server_label: string;
+  server_url: string;
+  api_key?: string;
+}
+
+export function loadRemoteMcpTools() {
+  try {
+    const filePath = join(__dirname, "../../data/mcp-tools.json");
+    const raw = readFileSync(filePath, "utf-8");
+    const configs: RemoteMcpConfig[] = JSON.parse(raw);
+    return configs.map(cfg => {
+      const tool: any = {
+        type: "mcp",
+        server_label: cfg.server_label,
+        server_url: cfg.server_url
+      };
+      if (cfg.api_key) {
+        tool.headers = { Authorization: `Bearer ${cfg.api_key}` };
+      }
+      return tool;
+    });
+  } catch (err) {
+    console.warn("No remote MCP tools loaded", err instanceof Error ? err.message : err);
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- load remote MCP server definitions from `data/mcp-tools.json`
- expose remote MCP tools only to the supervisor agent; base agent uses only local function tools

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run backend:build`


------
https://chatgpt.com/codex/tasks/task_e_689489ed55ec8328a6bc5be8562f846b