### PR TITLE
Serve canvas content via link

### DIFF
--- a/websocket-server/package-lock.json
+++ b/websocket-server/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "twilio-realtime",
+  "name": "delegate1-server",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "twilio-realtime",
+      "name": "delegate1-server",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -17,6 +17,7 @@
         "express": "^4.21.2",
         "httpdispatcher": "^2.2.0",
         "https-proxy-agent": "^5.0.1",
+        "marked": "^16.1.2",
         "openai": "^4.67.3",
         "ts-node": "^10.9.2",
         "twilio": "^5.8.0",
@@ -2068,6 +2069,18 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+    },
+    "node_modules/marked": {
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.1.2.tgz",
+      "integrity": "sha512-rNQt5EvRinalby7zJZu/mB+BvaAY2oz3wCuCjt1RDrWNpS1Pdf9xqMOeC9Hm5adBdcV/3XZPJpG58eT+WBc0XQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.0.0",

--- a/websocket-server/package.json
+++ b/websocket-server/package.json
@@ -22,6 +22,7 @@
     "express": "^4.21.2",
     "httpdispatcher": "^2.2.0",
     "https-proxy-agent": "^5.0.1",
+    "marked": "^16.1.2",
     "openai": "^4.67.3",
     "ts-node": "^10.9.2",
     "twilio": "^5.8.0",

--- a/websocket-server/src/agentConfigs/canvasTool.ts
+++ b/websocket-server/src/agentConfigs/canvasTool.ts
@@ -1,5 +1,8 @@
 import { FunctionHandler } from './types';
 import { WebSocket } from 'ws';
+import { storeCanvas } from '../canvasStore';
+
+const PUBLIC_URL = process.env.PUBLIC_URL || '';
 
 function jsonSend(ws: WebSocket | undefined, obj: unknown) {
   if (!ws || ws.readyState !== WebSocket.OPEN) return;
@@ -22,7 +25,9 @@ export const sendCanvas: FunctionHandler = {
     }
   },
   handler: async ({ content, title }: { content: string; title?: string }) => {
-    const message = { type: "chat.canvas", content, title, timestamp: Date.now() };
+    const id = storeCanvas(content, title);
+    const link = `${PUBLIC_URL}/canvas/${id}`;
+    const message = { type: "chat.canvas", content: link, title, timestamp: Date.now() };
 
     const globals = globalThis as any;
     const chatClients: Set<WebSocket> = globals.chatClients ?? new Set();

--- a/websocket-server/src/canvasStore.ts
+++ b/websocket-server/src/canvasStore.ts
@@ -1,0 +1,19 @@
+import { randomUUID } from 'crypto';
+
+interface CanvasData {
+  content: string;
+  title?: string;
+  timestamp: number;
+}
+
+const canvasStore = new Map<string, CanvasData>();
+
+export function storeCanvas(content: string, title?: string): string {
+  const id = randomUUID();
+  canvasStore.set(id, { content, title, timestamp: Date.now() });
+  return id;
+}
+
+export function getCanvas(id: string): CanvasData | undefined {
+  return canvasStore.get(id);
+}

--- a/websocket-server/src/server.ts
+++ b/websocket-server/src/server.ts
@@ -12,6 +12,8 @@ import { establishChatSocket } from "./session/chat";
 import { processSmsWebhook } from "./session/sms";
 import functions from "./functionHandlers";
 import { getLogs } from "./logBuffer";
+import { getCanvas } from "./canvasStore";
+import { marked } from "marked";
 
 dotenv.config();
 
@@ -69,6 +71,17 @@ app.get("/tools", (req, res) => {
 // Endpoint to retrieve latest server logs
 app.get("/logs", (req, res) => {
   res.type("text/plain").send(getLogs().join("\n"));
+});
+
+// Endpoint to serve stored canvas content as HTML
+app.get("/canvas/:id", (req, res) => {
+  const data = getCanvas(req.params.id);
+  if (!data) {
+    res.status(404).send("Not found");
+    return;
+  }
+  const html = marked.parse(data.content);
+  res.send(`<!doctype html><html><head><title>${data.title || "Canvas"}</title></head><body>${html}</body></html>`);
 });
 
 // Access token endpoint for voice client


### PR DESCRIPTION
## Summary
- Generate a GUID for canvas output and store markdown content in-memory
- Deliver canvas responses as unique links instead of raw text
- Serve stored markdown via `/canvas/:id` endpoint rendered with **marked**

## Testing
- `npm test` (fails: no test specified)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6896e34761d88328962f5fb5afee0f8f