### PR TITLE
Skip unique commit check on main branch in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,15 +21,20 @@ jobs:
           echo "DEBUG: Branch name: ${{ github.ref_name }}"
           # Fetch main branch to ensure we have the latest data
           git fetch origin main --quiet
-          # Count commits that are on this branch but not on main
-          UNIQUE_COMMITS=$(git rev-list --count origin/main..HEAD)
-          echo "DEBUG: Unique commits not on main: $UNIQUE_COMMITS"
-          if [ "$UNIQUE_COMMITS" -eq 0 ]; then
-            echo "should_continue=false" >> $GITHUB_OUTPUT
-            echo "DEBUG: should_continue set to false (no unique commits on branch)"
-          else
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            echo "DEBUG: On main branch; skipping unique commit check"
             echo "should_continue=true" >> $GITHUB_OUTPUT
-            echo "DEBUG: should_continue set to true ($UNIQUE_COMMITS unique commits found)"
+          else
+            # Count commits that are on this branch but not on main
+            UNIQUE_COMMITS=$(git rev-list --count origin/main..HEAD)
+            echo "DEBUG: Unique commits not on main: $UNIQUE_COMMITS"
+            if [ "$UNIQUE_COMMITS" -eq 0 ]; then
+              echo "should_continue=false" >> $GITHUB_OUTPUT
+              echo "DEBUG: should_continue set to false (no unique commits on branch)"
+            else
+              echo "should_continue=true" >> $GITHUB_OUTPUT
+              echo "DEBUG: should_continue set to true ($UNIQUE_COMMITS unique commits found)"
+            fi
           fi
 
   build-frontend:


### PR DESCRIPTION
## Summary
- skip unique commit check in deploy workflow when running on `main` branch to avoid false failures

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897037f92288328bcf20203bcd99090