### PR TITLE
Make settings panel closable and scrollable

### DIFF
--- a/webapp/components/call-interface.tsx
+++ b/webapp/components/call-interface.tsx
@@ -2,8 +2,8 @@
 
 import React, { useState, useEffect } from "react";
 import TopBar from "@/components/top-bar";
-import { Dialog, DialogTrigger, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import { Settings } from "lucide-react";
+import { Dialog, DialogTrigger, DialogContent, DialogTitle, DialogClose } from "@/components/ui/dialog";
+import { Settings, X } from "lucide-react";
 import SessionConfigurationPanel from "@/components/session-configuration-panel";
 import { EnhancedTranscript } from "@/components/enhanced-transcript";
 
@@ -142,11 +142,15 @@ const CallInterface = () => {
             </button>
           </DialogTrigger>
         </TopBar>
-        <DialogContent className="max-w-md w-full sm:max-w-lg">
+        <DialogContent className="max-w-md w-full sm:max-w-lg max-h-[90vh] overflow-y-auto">
           {/* Accessibility: DialogTitle for screen readers */}
           <span style={{position: 'absolute', width: 1, height: 1, padding: 0, margin: -1, overflow: 'hidden', clip: 'rect(0,0,0,0)', border: 0}}>
             <DialogTitle>Session Settings</DialogTitle>
           </span>
+          <DialogClose className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </DialogClose>
           <div className="space-y-5">
 
             <SessionConfigurationPanel


### PR DESCRIPTION
## Summary
- add an explicit close button to the settings dialog
- constrain dialog height and enable scrolling for long content

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68986a895ad08328b51ff81e19eb126e