### PR TITLE
Ensure assistant responses are sent via SMS

### DIFF
--- a/websocket-server/src/session/chat.ts
+++ b/websocket-server/src/session/chat.ts
@@ -330,6 +330,12 @@ export async function handleTextChatMessage(
                   supervisor: true,
                 };
                 session.conversationHistory.push(confirmMsg);
+                if (isSmsWindowOpen()) {
+                  const { smsUserNumber, smsTwilioNumber } = getNumbers();
+                  sendSms(confirmText, smsTwilioNumber, smsUserNumber).catch((e) =>
+                    console.error("sendSms error", e)
+                  );
+                }
                 for (const ws of chatClients) {
                   if (isOpen(ws))
                     jsonSend(ws, {
@@ -368,6 +374,12 @@ export async function handleTextChatMessage(
             supervisor: true,
           };
           session.conversationHistory.push(assistantMessage);
+          if (isSmsWindowOpen()) {
+            const { smsUserNumber, smsTwilioNumber } = getNumbers();
+            sendSms(finalResponse, smsTwilioNumber, smsUserNumber).catch((e) =>
+              console.error("sendSms error", e)
+            );
+          }
           for (const ws of chatClients) {
             if (isOpen(ws))
               jsonSend(ws, {
@@ -408,6 +420,12 @@ export async function handleTextChatMessage(
       supervisor: false,
     };
     session.conversationHistory.push(assistantMessage);
+    if (isSmsWindowOpen()) {
+      const { smsUserNumber, smsTwilioNumber } = getNumbers();
+      sendSms(assistantText, smsTwilioNumber, smsUserNumber).catch((e) =>
+        console.error("sendSms error", e)
+      );
+    }
     for (const ws of chatClients) {
       if (isOpen(ws))
         jsonSend(ws, { type: "chat.response", content: assistantText, timestamp: Date.now() });


### PR DESCRIPTION
## Summary
- Send SMS reply whenever the assistant sends final text responses
- Include SMS delivery for canvas confirmation messages

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd websocket-server && npm test` *(fails: Error: no test specified)*
- `cd websocket-server && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898768baac4832880462a932fe8f038