### PR TITLE
Persist and replay canvas artifacts

### DIFF
--- a/websocket-server/src/server.ts
+++ b/websocket-server/src/server.ts
@@ -78,8 +78,8 @@ app.get("/logs", (req, res) => {
 });
 
 // Endpoint to serve stored canvas content as HTML
-app.get("/canvas/:id", (req, res) => {
-  const data = getCanvas(req.params.id);
+app.get("/canvas/:id", async (req, res) => {
+  const data = await getCanvas(req.params.id);
   if (!data) {
     res.status(404).send("Not found");
     return;

--- a/websocket-server/src/session/call.ts
+++ b/websocket-server/src/session/call.ts
@@ -1,6 +1,6 @@
 import { RawData, WebSocket } from "ws";
 import { getAllFunctions, getDefaultAgent, FunctionHandler } from "../agentConfigs";
-import { session, parseMessage, jsonSend, isOpen, closeAllConnections, closeModel } from "./state";
+import { session, parseMessage, jsonSend, isOpen, closeAllConnections, closeModel, type ConversationItem } from "./state";
 
 // Explicitly type globalThis for logsClients/chatClients to avoid TS7017
 declare global {
@@ -219,14 +219,14 @@ export function processRealtimeModelEvent(
           if (!session.conversationHistory) {
             session.conversationHistory = [];
           }
-          const assistantMessage: { type: 'user' | 'assistant', content: string, timestamp: number, channel: 'voice' | 'text', supervisor?: boolean } = {
-            type: 'assistant' as const,
-            content: textContent.text,
-            timestamp: Date.now(),
-            channel: 'text' as const,
-            supervisor: false,
-          };
-          session.conversationHistory.push(assistantMessage);
+            const assistantMessage: ConversationItem = {
+              type: 'assistant',
+              content: textContent.text,
+              timestamp: Date.now(),
+              channel: 'text',
+              supervisor: false,
+            };
+            session.conversationHistory.push(assistantMessage);
           for (const ws of chatClients) {
             if (isOpen(ws)) jsonSend(ws, {
               type: "chat.response",

--- a/websocket-server/src/session/chat.ts
+++ b/websocket-server/src/session/chat.ts
@@ -26,6 +26,14 @@ export function establishChatSocket(
         timestamp: msg.timestamp,
         supervisor: msg.supervisor,
       });
+    } else if (msg.type === 'canvas') {
+      jsonSend(ws, {
+        type: 'chat.canvas',
+        content: msg.content,
+        title: msg.title,
+        timestamp: msg.timestamp,
+        id: msg.id,
+      });
     }
   }
   ws.on("message", (data) => processChatSocketMessage(data, chatClients, logsClients));

--- a/websocket-server/src/session/logs.ts
+++ b/websocket-server/src/session/logs.ts
@@ -7,17 +7,27 @@ export function establishLogsSocket(ws: WebSocket, logsClients: Set<WebSocket>) 
   // for new events. This stream is consumed by the web frontend at `/logs`.
   if (session.conversationHistory) {
     for (const msg of session.conversationHistory) {
-      jsonSend(ws, {
-        type: "conversation.item.created",
-        item: {
-          id: `msg_${msg.timestamp}`,
-          type: "message",
-          role: msg.type,
-          content: [{ type: "text", text: msg.content }],
-          channel: msg.channel,
-          supervisor: msg.supervisor,
-        },
-      });
+      if (msg.type === 'canvas') {
+        jsonSend(ws, {
+          type: 'chat.canvas',
+          content: msg.content,
+          title: msg.title,
+          timestamp: msg.timestamp,
+          id: msg.id,
+        });
+      } else {
+        jsonSend(ws, {
+          type: "conversation.item.created",
+          item: {
+            id: `msg_${msg.timestamp}`,
+            type: "message",
+            role: msg.type,
+            content: [{ type: "text", text: msg.content }],
+            channel: msg.channel,
+            supervisor: msg.supervisor,
+          },
+        });
+      }
     }
   }
 

--- a/websocket-server/src/session/state.ts
+++ b/websocket-server/src/session/state.ts
@@ -1,6 +1,22 @@
 import { RawData, WebSocket } from "ws";
 
 // Mirror of the Session shape used by the current sessionManager
+export type ConversationItem =
+  | {
+      type: 'user' | 'assistant';
+      content: string;
+      timestamp: number;
+      channel: 'voice' | 'text';
+      supervisor?: boolean;
+    }
+  | {
+      type: 'canvas';
+      content: string; // URL to stored canvas
+      title?: string;
+      timestamp: number;
+      id: string;
+    };
+
 export interface Session {
   twilioConn?: WebSocket;
   frontendConn?: WebSocket;
@@ -14,13 +30,7 @@ export interface Session {
   responseStartTimestamp?: number;
   latestMediaTimestamp?: number;
   openAIApiKey?: string;
-  conversationHistory?: Array<{
-    type: 'user' | 'assistant',
-    content: string,
-    timestamp: number,
-    channel: 'voice' | 'text',
-    supervisor?: boolean
-  }>;
+  conversationHistory?: ConversationItem[];
   previousResponseId?: string; // For Responses API conversation tracking
 }
 


### PR DESCRIPTION
## Summary
- persist canvas tool output to disk with an ID-based store
- record canvas artifacts in conversation history and broadcast to clients
- replay stored canvas events to new chat and log connections

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix websocket-server test` *(fails: Error: no test specified)*
- `npm --prefix websocket-server run build`


------
https://chatgpt.com/codex/tasks/task_e_689bb9d3f2fc832882e1ffe00c89a022