### PR TITLE
feat: add note management tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ node_modules
 generate-token.js
 .DS_Store
 websocket-server/session-data.json
+websocket-server/notes.json
 websocket-server/dist
 scripts/localtunnel/*.log

--- a/websocket-server/src/agentConfigs/baseAgentConfig.ts
+++ b/websocket-server/src/agentConfigs/baseAgentConfig.ts
@@ -3,6 +3,7 @@ import { getWeatherFunction } from '../tools/handlers/weather';
 import { sendCanvas } from '../tools/handlers/canvas';
 import { sendSmsTool } from '../tools/handlers/sms';
 import { memAddFunction, memSearchFunction } from '../tools/handlers/mem0';
+import { createNoteFunction, listNotesFunction, updateNoteFunction, deleteNoteFunction, listCategoriesFunction } from '../tools/handlers/notes';
 import { agentPersonality } from "./personality";
 
 // Base Agent Configuration
@@ -46,6 +47,11 @@ Persistent memory:
     sendSmsTool,
     memAddFunction,
     memSearchFunction,
+    createNoteFunction,
+    listNotesFunction,
+    updateNoteFunction,
+    deleteNoteFunction,
+    listCategoriesFunction,
   ],
   // Text (Responses API) model for chat interactions
   textModel: "gpt-5",

--- a/websocket-server/src/noteStore.ts
+++ b/websocket-server/src/noteStore.ts
@@ -1,0 +1,75 @@
+import { randomUUID } from 'crypto';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export interface NoteData {
+  id: string;
+  content: string;
+  tags?: string[];
+  timestamp: number;
+}
+
+const NOTES_FILE = path.join(__dirname, '..', 'notes.json');
+
+async function readAll(): Promise<NoteData[]> {
+  try {
+    const file = await fs.readFile(NOTES_FILE, 'utf-8');
+    return JSON.parse(file) as NoteData[];
+  } catch {
+    return [];
+  }
+}
+
+async function writeAll(notes: NoteData[]): Promise<void> {
+  await fs.writeFile(NOTES_FILE, JSON.stringify(notes, null, 2), 'utf-8');
+}
+
+export async function createNote(content: string, tags: string[] = []): Promise<NoteData> {
+  const notes = await readAll();
+  const note: NoteData = { id: randomUUID(), content, tags, timestamp: Date.now() };
+  notes.push(note);
+  await writeAll(notes);
+  return note;
+}
+
+export async function listNotes(filter?: { tag?: string; query?: string }): Promise<NoteData[]> {
+  let notes = await readAll();
+  if (filter?.tag) {
+    const tag = filter.tag;
+    notes = notes.filter(n => n.tags?.includes(tag));
+  }
+  if (filter?.query) {
+    const q = filter.query.toLowerCase();
+    notes = notes.filter(n => n.content.toLowerCase().includes(q));
+  }
+  return notes;
+}
+
+export async function updateNote(id: string, content?: string, tags?: string[]): Promise<NoteData | undefined> {
+  const notes = await readAll();
+  const note = notes.find(n => n.id === id);
+  if (!note) return undefined;
+  if (content !== undefined) note.content = content;
+  if (tags !== undefined) note.tags = tags;
+  note.timestamp = Date.now();
+  await writeAll(notes);
+  return note;
+}
+
+export async function deleteNote(id: string): Promise<boolean> {
+  const notes = await readAll();
+  const idx = notes.findIndex(n => n.id === id);
+  if (idx === -1) return false;
+  notes.splice(idx, 1);
+  await writeAll(notes);
+  return true;
+}
+
+export async function listCategories(): Promise<string[]> {
+  const notes = await readAll();
+  const set = new Set<string>();
+  for (const n of notes) {
+    if (n.tags) for (const t of n.tags) set.add(t);
+  }
+  return Array.from(set);
+}

--- a/websocket-server/src/tools/handlers/notes.ts
+++ b/websocket-server/src/tools/handlers/notes.ts
@@ -1,0 +1,105 @@
+import { FunctionHandler } from '../../agentConfigs/types';
+import { createNote, listNotes, updateNote, deleteNote, listCategories } from '../../noteStore';
+
+export const createNoteFunction: FunctionHandler = {
+  schema: {
+    name: 'create_note',
+    type: 'function',
+    description: 'Create a new note with optional tags for categorization.',
+    parameters: {
+      type: 'object',
+      properties: {
+        content: { type: 'string' },
+        tags: { type: 'array', items: { type: 'string' } }
+      },
+      required: ['content'],
+      additionalProperties: false
+    }
+  },
+  handler: async ({ content, tags }: { content: string; tags?: string[] }) => {
+    const note = await createNote(content, Array.isArray(tags) ? tags : []);
+    return { status: 'created', note_id: note.id, content: note.content, tags: note.tags ?? [] };
+  }
+};
+
+export const listNotesFunction: FunctionHandler = {
+  schema: {
+    name: 'list_notes',
+    type: 'function',
+    description: 'List existing notes, optionally filtered by tag or search query.',
+    parameters: {
+      type: 'object',
+      properties: {
+        tag: { type: 'string', description: 'Return only notes with this tag.' },
+        query: { type: 'string', description: 'Full text search within note content.' }
+      },
+      required: [],
+      additionalProperties: false
+    }
+  },
+  handler: async ({ tag, query }: { tag?: string; query?: string }) => {
+    const notes = await listNotes({ tag, query });
+    return { notes };
+  }
+};
+
+export const updateNoteFunction: FunctionHandler = {
+  schema: {
+    name: 'update_note',
+    type: 'function',
+    description: 'Update an existing note\'s content or tags.',
+    parameters: {
+      type: 'object',
+      properties: {
+        note_id: { type: 'string' },
+        content: { type: 'string' },
+        tags: { type: 'array', items: { type: 'string' } }
+      },
+      required: ['note_id'],
+      additionalProperties: false
+    }
+  },
+  handler: async ({ note_id, content, tags }: { note_id: string; content?: string; tags?: string[] }) => {
+    const note = await updateNote(note_id, content, tags);
+    if (!note) return { error: 'not_found' };
+    return { status: 'updated', note_id: note.id, content: note.content, tags: note.tags ?? [] };
+  }
+};
+
+export const deleteNoteFunction: FunctionHandler = {
+  schema: {
+    name: 'delete_note',
+    type: 'function',
+    description: 'Delete a note by its identifier.',
+    parameters: {
+      type: 'object',
+      properties: {
+        note_id: { type: 'string' }
+      },
+      required: ['note_id'],
+      additionalProperties: false
+    }
+  },
+  handler: async ({ note_id }: { note_id: string }) => {
+    const ok = await deleteNote(note_id);
+    return { status: ok ? 'deleted' : 'not_found' };
+  }
+};
+
+export const listCategoriesFunction: FunctionHandler = {
+  schema: {
+    name: 'list_categories',
+    type: 'function',
+    description: 'List all unique tags used across notes.',
+    parameters: {
+      type: 'object',
+      properties: {},
+      required: [],
+      additionalProperties: false
+    }
+  },
+  handler: async () => {
+    const categories = await listCategories();
+    return { categories };
+  }
+};

--- a/websocket-server/src/tools/providers/local.ts
+++ b/websocket-server/src/tools/providers/local.ts
@@ -5,6 +5,7 @@ import { sendSmsTool } from "../handlers/sms";
 import { getCurrentTimeFunction } from "../handlers/current-time";
 import { getNextResponseFromSupervisorFunction } from "../handlers/supervisor-escalation";
 import { memAddFunction, memSearchFunction } from "../handlers/mem0";
+import { createNoteFunction, listNotesFunction, updateNoteFunction, deleteNoteFunction, listCategoriesFunction } from "../handlers/notes";
 
 function wrap(name: string, description: string, parameters: any, origin: ToolOrigin, tags: string[], handler: (args: any) => Promise<any>) {
   return {
@@ -82,6 +83,46 @@ export function registerLocalTools() {
       'local',
       ['local', 'base-default'],
       (args) => memSearchFunction.handler(args)
+    ),
+    wrap(
+      createNoteFunction.schema.name,
+      createNoteFunction.schema.description,
+      createNoteFunction.schema.parameters,
+      'local',
+      ['local', 'base-default'],
+      (args) => createNoteFunction.handler(args)
+    ),
+    wrap(
+      listNotesFunction.schema.name,
+      listNotesFunction.schema.description,
+      listNotesFunction.schema.parameters,
+      'local',
+      ['local', 'base-default'],
+      (args) => listNotesFunction.handler(args)
+    ),
+    wrap(
+      updateNoteFunction.schema.name,
+      updateNoteFunction.schema.description,
+      updateNoteFunction.schema.parameters,
+      'local',
+      ['local', 'base-default'],
+      (args) => updateNoteFunction.handler(args)
+    ),
+    wrap(
+      deleteNoteFunction.schema.name,
+      deleteNoteFunction.schema.description,
+      deleteNoteFunction.schema.parameters,
+      'local',
+      ['local', 'base-default'],
+      (args) => deleteNoteFunction.handler(args)
+    ),
+    wrap(
+      listCategoriesFunction.schema.name,
+      listCategoriesFunction.schema.description,
+      listCategoriesFunction.schema.parameters,
+      'local',
+      ['local', 'base-default'],
+      (args) => listCategoriesFunction.handler(args)
     ),
   ];
   registerTools(providerId, tools);


### PR DESCRIPTION
## Summary
- add file-based note store and tool handlers for creating, listing, updating, deleting, and categorizing notes
- register note tools and expose to base agent

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run backend:build`


------
https://chatgpt.com/codex/tasks/task_e_68b37688f2548328aafce130b2c4f420