### PR TITLE
feat: add hang up tool for voice calls

### DIFF
--- a/websocket-server/src/agentConfigs/baseAgentConfig.ts
+++ b/websocket-server/src/agentConfigs/baseAgentConfig.ts
@@ -4,6 +4,7 @@ import { sendCanvas } from '../tools/handlers/canvas';
 import { sendSmsTool } from '../tools/handlers/sms';
 import { memAddFunction, memSearchFunction } from '../tools/handlers/mem0';
 import { createNoteFunction, listNotesFunction, updateNoteFunction, deleteNoteFunction } from '../tools/handlers/notes';
+import { hangupCallTool } from '../tools/handlers/hangup';
 import { agentPersonality } from "./personality";
 
 // Base Agent Configuration
@@ -51,6 +52,7 @@ Persistent memory:
     listNotesFunction,
     updateNoteFunction,
     deleteNoteFunction,
+    hangupCallTool,
   ],
   // Text (Responses API) model for chat interactions
   textModel: "gpt-5",

--- a/websocket-server/src/agentConfigs/channel.ts
+++ b/websocket-server/src/agentConfigs/channel.ts
@@ -1,5 +1,9 @@
 export type Channel = 'voice' | 'text' | 'sms';
 
 export function channelInstructions(channel: Channel): string {
-  return `Current communication channel: ${channel}.`;
+  let base = `Current communication channel: ${channel}.`;
+  if (channel === 'voice') {
+    base += ' When the conversation is over or the caller says goodbye, use the hang_up tool to end the call.';
+  }
+  return base;
 }

--- a/websocket-server/src/tools/handlers/hangup.ts
+++ b/websocket-server/src/tools/handlers/hangup.ts
@@ -1,0 +1,25 @@
+import { FunctionHandler } from '../../agentConfigs/types';
+import { session, jsonSend, closeAllConnections, isOpen } from '../../session/state';
+
+export const hangupCallTool: FunctionHandler = {
+  schema: {
+    name: 'hang_up',
+    type: 'function',
+    description: 'End the current voice call with the user.',
+    parameters: {
+      type: 'object',
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    },
+  },
+  handler: async () => {
+    if (session.twilioConn && isOpen(session.twilioConn)) {
+      jsonSend(session.twilioConn, { event: 'close' });
+    }
+    closeAllConnections();
+    return { status: 'closed' };
+  },
+};
+
+export default hangupCallTool;


### PR DESCRIPTION
## Summary
- add `hang_up` tool handler to end active voice calls
- register tool for base agent and instruct voice channel to invoke it when caller is done
- simplify chat tool selection by removing manual hang_up filter

## Testing
- `npm test` (websocket-server) *(fails: Error: no test specified)*
- `npm run build` (websocket-server)
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b62f284d388328907c2d29ab25d9e8