### PR TITLE
Handle missing canvas content

### DIFF
--- a/websocket-server/src/server.ts
+++ b/websocket-server/src/server.ts
@@ -225,7 +225,7 @@ app.get("/canvas/:id", async (req, res) => {
     res.status(404).send("Not found");
     return;
   }
-  const html = marked.parse(data.content);
+  const html = marked.parse(data.content ?? "");
   res.send(`<!doctype html><html><head><title>${data.title || "Canvas"}</title></head><body>${html}</body></html>`);
 });
 


### PR DESCRIPTION
## Summary
- avoid parsing undefined canvas content with marked

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbe227af1483288c1c131bbb10a1d0